### PR TITLE
Fix-prop-float

### DIFF
--- a/Decompiler/PscCoder.cpp
+++ b/Decompiler/PscCoder.cpp
@@ -686,6 +686,7 @@ void str_to_lower(std::string &p_str){
 */
 std::string Decompiler::PscCoder::mapType(std::string type)
 {
+    std::replace(type.begin(), type.end(), '#', ':');
     if (type.length() > 2 && type[type.length() - 2] == '[' && type[type.length() - 1] == ']')
         return mapType(type.substr(0, type.length() - 2)) + "[]";
     auto lowerType = type;

--- a/Pex/Value.cpp
+++ b/Pex/Value.cpp
@@ -297,7 +297,7 @@ std::string Pex::Value::toString() const
             for (; i >= 0; i--) {
                 if (str[i] != '0') {
                     if (str[i] == '.')
-                        i--;
+                        i++;
                     break;
                 }
             }


### PR DESCRIPTION
float initalizers without `.0` at the end were rejected by PCompiler